### PR TITLE
disable arango authentication when username and password are provided…

### DIFF
--- a/driver/src/main/scala/com/outr/arango/Arango.scala
+++ b/driver/src/main/scala/com/outr/arango/Arango.scala
@@ -46,6 +46,8 @@ class Arango(baseURL: URL = Arango.defaultURL) {
     client.call[Response](url, method, headers, errorHandler.getOrElse(defaultErrorHandler(path)))
   }
 
+  def noAuth(): Future[ArangoSession ] = Future.successful( new ArangoSession(this, "null"))
+
   def auth(username: String = Arango.defaultUsername,
            password: String = Arango.defaultPassword): Future[ArangoSession] = {
     restful[AuthenticationRequest, AuthenticationResponse]("/_open/auth", AuthenticationRequest(username, password), None).map { response =>

--- a/driver/src/main/scala/com/outr/arango/managed/Graph.scala
+++ b/driver/src/main/scala/com/outr/arango/managed/Graph.scala
@@ -19,7 +19,11 @@ class Graph(name: String,
             password: String = Arango.defaultPassword,
             timeout: FiniteDuration = 15.seconds) {
   private[managed] lazy val arango: Arango = new Arango(url)
-  private[managed] lazy val sessionFuture: Future[ArangoSession] = arango.auth(username, password)
+  private[managed] lazy val sessionFuture: Future[ArangoSession] = if( username.isEmpty && password.isEmpty ) {
+    arango.noAuth()
+  } else {
+    arango.auth( username, password )
+  }
   private[managed] lazy val dbFuture: Future[ArangoDB] = sessionFuture.map(_.db(db))
   private[managed] lazy val graphFuture: Future[ArangoGraph] = dbFuture.map(_.graph(name))
 


### PR DESCRIPTION
disable arango authentication when username and password are provided as empty strings.

the simplest way to do this is to provide "null" as the bearer token (following the internal foxx application)